### PR TITLE
Remove 'does something useful' spec

### DIFF
--- a/spec/heyupdate_spec.rb
+++ b/spec/heyupdate_spec.rb
@@ -4,8 +4,4 @@ describe Heyupdate do
   it 'has a version number' do
     expect(Heyupdate::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Default spec was causing Semaphore build to fail.